### PR TITLE
Adds Not() to invert error checkers

### DIFF
--- a/options.go
+++ b/options.go
@@ -11,6 +11,13 @@ const (
 	DefaultTimeout  = time.Duration(15 * time.Second)
 )
 
+// Not is a helper to invert another .
+func Not(checker func(err error) bool) func(err error) bool {
+	return func(err error) bool {
+		return !checker(err)
+	}
+}
+
 type RetryOption func(options *retryOptions)
 
 // Timeout specifies the maximum time that should be used before aborting the retry loop.


### PR DESCRIPTION
I noticed I started adding such a function twice already to various packages to easiy usage of retry-go. Lets just add it here.